### PR TITLE
NASAEARTH-14 update all value functions

### DIFF
--- a/playwright/in-codap.spec.ts
+++ b/playwright/in-codap.spec.ts
@@ -3,7 +3,7 @@ import { test } from "./fixtures.js";
 
 test("App inside of CODAP", async ({ baseURL, page }) => {
   await page.setViewportSize({width: 1400, height: 800});
-  const diUrl = baseURL;
+  const diUrl = `${baseURL}?maxImages=10`;
   // eslint-disable-next-line playwright/no-conditional-in-test
   if (!diUrl) {
     throw new Error("baseURL is not defined");
@@ -48,7 +48,7 @@ test("App inside of CODAP", async ({ baseURL, page }) => {
 
   const mapTile = page.getByTestId("codap-map");
   const mapTitle = mapTile.getByTestId("component-title-bar");
-  await expect(mapTitle).toContainText("2001-03-01");
+  await expect(mapTitle).toContainText("2001-02-01");
 
   const iframeUrl = await iframe.owner().getAttribute("src");
   // eslint-disable-next-line playwright/no-conditional-in-test

--- a/src/models/config.ts
+++ b/src/models/config.ts
@@ -28,7 +28,7 @@ export const kImageLoadDelay = 500;
  * This blocking applied to the whole website not just downloading images.
  * So to be safe, the number of images is limited to 100.
  */
-export const kMaxImages = 100;
+export const kMaxSerialImages = 100;
 
 /**
  * Whether to use the S3 bucket to download images at runtime.

--- a/src/models/data-manager.ts
+++ b/src/models/data-manager.ts
@@ -84,7 +84,7 @@ export class DataManager {
   }
 
   /**
-   * Processes a single image and extracts its color at the demo location
+   * Processes a single image and extracts its color at the pin locations
    * @param image - Dataset image metadata
    * @returns Promise resolving to a DatasetItem with date and color
    */

--- a/src/models/neo-dataset-config.test.ts
+++ b/src/models/neo-dataset-config.test.ts
@@ -2,21 +2,29 @@ import { kNeoDatasetConfigs } from "./neo-dataset-configs";
 
 describe("paletteToValue", () => {
   const valuesThatReturnNull = [-1, 255, 256];
-  const valuesThatReturnANumber = [0, 10, 200];
+  const valuesThatReturnANumber = [10, 200];
 
   // Test each dataset's paletteToValue function
   kNeoDatasetConfigs.forEach((config) => {
     const { id, paletteToValue } = config;
     describe(`Dataset ID: ${id}`, () => {
+      const extraNullValues = [];
+      const extraNumberValues = [];
 
-      valuesThatReturnNull.forEach((input) => {
+      if (config.id === "MOD14A1_M_FIRE") {
+        extraNullValues.push(0);
+      } else {
+        extraNumberValues.push(0);
+      }
+
+      [...extraNullValues, ...valuesThatReturnNull].forEach((input) => {
         test(`invalid or missing paletteToValue(${input})`, () => {
           const result = paletteToValue(input);
 
           expect(result).toBeNull();
         });
       });
-      valuesThatReturnANumber.forEach((input) => {
+      [...extraNumberValues, ...valuesThatReturnANumber].forEach((input) => {
         test(`valid paletteToValue(${input})`, () => {
           const result = paletteToValue(input);
           expect(result).toBeDefined();

--- a/src/models/neo-dataset-configs.ts
+++ b/src/models/neo-dataset-configs.ts
@@ -39,7 +39,7 @@ export const kNeoDatasetConfigs: NeoDatasetConfig[] = [
       if (index < 0 || index >= 255) {
         return null;
       }
-      return index/255 * 300;
+      return index/254 * 300;
     }
   },
   {
@@ -53,7 +53,7 @@ export const kNeoDatasetConfigs: NeoDatasetConfig[] = [
       if (index < 0 || index >= 255) {
         return null;
       }
-      return index/255 * 1500;
+      return index/254 * 1500.2;
     }
   },
   {
@@ -67,7 +67,7 @@ export const kNeoDatasetConfigs: NeoDatasetConfig[] = [
       if (index < 0 || index >= 255) {
         return null;
       }
-      return index/255 - 0.1;
+      return index/254 - 0.1;
     }
   },
   {
@@ -81,7 +81,7 @@ export const kNeoDatasetConfigs: NeoDatasetConfig[] = [
       if (index < 0 || index >= 255) {
         return null;
       }
-      return index/255 * 70 - 25;
+      return index/254 * 70 - 25;
     }
   },
   {
@@ -90,14 +90,23 @@ export const kNeoDatasetConfigs: NeoDatasetConfig[] = [
     legendImage: "https://neo.gsfc.nasa.gov/palettes/modis_fire_l3.png",
     paletteToValue: (index: number) => {
       // Convert palette index to fire pixels / 1000 km^2 / day
-      // The values are outside of the range, or they are 255 which seems
-      // to indicate no data
-      if (index < 0 || index >= 255) {
+
+      // Outside of the range just return null
+      if (index < 0 || index > 255) {
         return null;
       }
-      // FIXME: this is logarithmic so we need to analyze the data to find the actual
-      // scale.
-      return index/255 * 30.1 - 0.1;
+
+      if (index === 0 || index === 255) {
+        // Palette index 0 actually fits the curve and has a value of 0.1.
+        // However its color is black (0, 0, 0), which is the same color used for palette index 255.
+        // Since we don't have access to the actual palette index at runtime, we have to lookup
+        // the palette index from the color. So if we find black we don't know if it is palette index
+        // 0 or 255. Currently there are more pixels with index 255 than 0. So for now we'll
+        // just treat palette index 0 and 255 the same and return null.
+        return null;
+      }
+
+      return 0.09998920216570711 * Math.E ** (0.022456632453790572 * index);
     }
   }
 ];


### PR DESCRIPTION
The main change here is an update to most of the `paletteToValue` functions for the datasets we support. The new functions were checked by using some scripts that will be added in a separate PR. These scripts create a mapping from palette index to physical value by using the both the png and csv images from the dataset. It matches up the pixels in both files to make a mapping from palette index to physical value. And then another script tries to find the best fitting linear or logarithmic function for the data. 

During this process a new issue came up:

Some of the palettes have duplicate colors for different palette indices. When checking the csv file these palette indices have different physical values. This means going from color to palette index to physical value will not always give the correct physical value.  In most cases these duplicate colors are next to each other. So the difference in the physical values are far apart and the error will probably be fine for this project.

However in one case, the fire dataset, black (0,0,0) is used for both the value `0.1` and for the invalid/no-data value `99999`. There aren't too many cases of `0.1` so for the time being black is always treated as the no-data value. This treatment of the paletteIndex 0, required an update to the jest tests of the `paletteFromValue` so it would expect to get `null` for index 0 only on the fire dataset.

Additionally this PR updates the `maxImages` url param so it works with the parallel loading of images. This way the tests can use it to be more reliable. Changing the number of images loaded also changes the scale of the slider, so the expectation of that test had to be updated.

NASAEARTH-14

