### PR TITLE
Updates graphs on data change

### DIFF
--- a/playwright/in-codap.spec.ts
+++ b/playwright/in-codap.spec.ts
@@ -77,12 +77,19 @@ test("App inside of CODAP", async ({ baseURL, page }) => {
   await expect(page.getByTestId("case-table")).toHaveCount(1);
   await expect(page.getByTestId("codap-slider")).toHaveCount(1);
   await expect(page.getByTestId("codap-map")).toHaveCount(1);
+  await expect(page.getByTestId("codap-graph")).toHaveCount(2);
 
-  // Need to wait for fix in CODAP to get the correct graph
   //make sure the graph opens and have the correct axes attributes
-  // await expect(page.getByTestId("codap-graph")).toHaveCount(1);
-  // await expect(page.locator(".Graph-title-bar")).toContainText("Rainfall Chart");
-  // await expect(page.getByTestId("axis-legend-attribute-button-bottom")).toContainText("label");
-  // await expect(page.getByTestId("axis-legend-attribute-button-left")).toContainText("date");
-  // await expect(page.getByTestId("axis-legend-attribute-button-legend")).toContainText("color");
+  await expect(page.locator(".Graph-title-bar").nth(0)).toContainText("Rainfall Plot");
+  await expect(page.getByTestId("axis-legend-attribute-button-bottom").nth(0)).toContainText("date");
+  await expect(page.getByTestId("axis-legend-attribute-button-left").nth(0)).toContainText("value");
+  await expect(page.getByTestId("axis-legend-attribute-button-legend").nth(0)).toContainText("pinColor");
+  page.getByTestId("codap-graph").nth(0).click({ position: { x: 10, y: 10 } });
+  await expect(page.getByTestId("graph-display-values-button")).toBeVisible();
+  page.getByTestId("graph-display-values-button").nth(0).click();
+  await expect(page.getByTestId("adornment-checkbox-connecting-lines")).toBeChecked();
+  await expect(page.locator(".Graph-title-bar").nth(1)).toContainText("Rainfall Chart");
+  await expect(page.getByTestId("axis-legend-attribute-button-bottom").nth(1)).toContainText("label");
+  await expect(page.getByTestId("axis-legend-attribute-button-left").nth(1)).toContainText("date");
+  await expect(page.getByTestId("axis-legend-attribute-button-legend").nth(1)).toContainText("color");
 });

--- a/playwright/in-codap.spec.ts
+++ b/playwright/in-codap.spec.ts
@@ -83,7 +83,7 @@ test("App inside of CODAP", async ({ baseURL, page }) => {
   await expect(page.locator(".Graph-title-bar").nth(0)).toContainText("Rainfall Plot");
   await expect(page.getByTestId("axis-legend-attribute-button-bottom").nth(0)).toContainText("date");
   await expect(page.getByTestId("axis-legend-attribute-button-left").nth(0)).toContainText("value");
-  await expect(page.getByTestId("axis-legend-attribute-button-legend").nth(0)).toContainText("pinColor");
+  await expect(page.getByTestId("axis-legend-attribute-button-legend").nth(0)).toContainText("label");
   page.getByTestId("codap-graph").nth(0).click({ position: { x: 10, y: 10 } });
   await expect(page.getByTestId("graph-display-values-button")).toBeVisible();
   page.getByTestId("graph-display-values-button").nth(0).click();

--- a/src/components/tabs/dataset-tab.tsx
+++ b/src/components/tabs/dataset-tab.tsx
@@ -5,8 +5,9 @@ import {
 } from "@concord-consortium/codap-plugin-api";
 import { reaction } from "mobx";
 import { observer } from "mobx-react-lite";
+import { kDataContextName } from "../../data/constants";
 import { kNeoDatasets } from "../../models/neo-datasets";
-import { DataManager, kDataContextName } from "../../models/data-manager";
+import { DataManager } from "../../models/data-manager";
 import { pluginState } from "../../models/plugin-state";
 import { isNonEmbedded } from "../../utils/embed-check";
 import { DatasetSelector } from "../dataset-selector/dataset-selector";

--- a/src/data/constants.ts
+++ b/src/data/constants.ts
@@ -10,6 +10,11 @@ export const kPinLatAttributeName = "pinLat";
 export const kPinLongAttributeName = "pinLong";
 export const kPinColorAttributeName = "pinColor";
 
+export const kDataContextName = "NEOPluginData";
+export const kXYGraphName = "NEOPlugin XY Graph";
+export const kChartGraphName = "NEOPlugin Chart Graph";
+export const kMapPinsCollectionName = "Map Pins";
+
 export const kMapName = "NeoMap";
 
 export const kSliderComponentName = "NeoSlider";

--- a/src/models/data-manager.ts
+++ b/src/models/data-manager.ts
@@ -10,20 +10,15 @@ import {
   sendMessage,
 } from "@concord-consortium/codap-plugin-api";
 import { decodePng } from "@concord-consortium/png-codec";
-import { kPinColorAttributeName } from "../data/constants";
+import { kChartGraphName, kDataContextName, kMapPinsCollectionName, kXYGraphName } from "../data/constants";
 import { createOrUpdateGraphs, createOrUpdateDateSlider, createOrUpdateMap, addConnectingLinesToGraph,
-  addRegionOfInterestToGraphs, updateGraphRegionOfInterest,
-  updateLocationColorMap
+  addRegionOfInterestToGraphs, updateGraphRegionOfInterest, updateLocationColorMap, rescaleGraph
 } from "../utils/codap-utils";
 import { GeoImage } from "./geo-image";
 import { NeoDataset, NeoImageInfo } from "./neo-types";
 import { kImageLoadDelay, kMaxSerialImages, kParallelLoad } from "./config";
 import { pinLabel, pluginState } from "./plugin-state";
 
-export const kDataContextName = "NEOPluginData";
-export const kXYGraphName = "NEOPlugin XY Graph";
-export const kChartGraphName = "NEOPlugin Chart Graph";
-export const kMapPinsCollectionName = "Map Pins";
 const kDatesCollectionName = "Available Dates";
 
 async function clearExistingCases(): Promise<void> {
@@ -312,6 +307,8 @@ export class DataManager {
       await addConnectingLinesToGraph();
       const roiPosition = getTimestamp(this.loadedImages[0]);
       await addRegionOfInterestToGraphs(roiPosition);
+      await rescaleGraph(kXYGraphName);
+      await rescaleGraph(kChartGraphName);
       // The codap-plugin-api does not support colormap property to attributes
       // so we update the attribute after the collection is created
       await updateLocationColorMap(pinColorMap);

--- a/src/models/data-manager.ts
+++ b/src/models/data-manager.ts
@@ -287,6 +287,9 @@ export class DataManager {
       await clearExistingCases();
       await createItems(kDataContextName, items);
       await createTable(kDataContextName);
+      // The codap-plugin-api does not apply colormap property to attributes
+      // so we update the attribute after the collection is created
+      await updateLocationColorMap(pinColorMap);
       // We can't add the connecting lines on the first graph creation so we update it later
       await createOrUpdateGraphs(kDataContextName,
         [ { name: kXYGraphName,
@@ -309,9 +312,7 @@ export class DataManager {
       await addRegionOfInterestToGraphs(roiPosition);
       await rescaleGraph(kXYGraphName);
       await rescaleGraph(kChartGraphName);
-      // The codap-plugin-api does not support colormap property to attributes
-      // so we update the attribute after the collection is created
-      await updateLocationColorMap(pinColorMap);
+
     } catch (error) {
       console.error("Failed to process dataset:", error);
       throw error;

--- a/src/utils/codap-utils.ts
+++ b/src/utils/codap-utils.ts
@@ -4,7 +4,7 @@ import {
   kPinLongAttributeName, kPluginName, kSliderComponentName, kVersion
 } from "../data/constants";
 import { pluginState } from "../models/plugin-state";
-import { kChartGraphName, kXYGraphName } from "../models/data-manager";
+import { kChartGraphName, kDataContextName, kMapPinsCollectionName, kXYGraphName } from "../models/data-manager";
 
 export async function initializeNeoPlugin() {
   initializePlugin({ pluginName: kPluginName, version: kVersion, dimensions: kInitialDimensions });
@@ -193,4 +193,13 @@ export const updateGraphRegionOfInterest = async (dataContext: string,position: 
     primary: {position, "extent": kOneMonthInSeconds}
   });
   return {roiXYGraph, roiCategoryChartGraph};
+};
+
+export const updateLocationColorMap = async (colorMap: Record<string,string>) => {
+  const updateColorMap =
+          await sendMessage(
+                  "update",
+                  `dataContext[${kDataContextName}].collection[${kMapPinsCollectionName}].attribute[${"label"}]`,
+                  { colormap: colorMap });
+  return updateColorMap;
 };

--- a/src/utils/codap-utils.ts
+++ b/src/utils/codap-utils.ts
@@ -1,10 +1,12 @@
-import { addDataContextChangeListener, initializePlugin, sendMessage } from "@concord-consortium/codap-plugin-api";
+import { addDataContextChangeListener, codapInterface, initializePlugin, sendMessage
+} from "@concord-consortium/codap-plugin-api";
 import {
-  kInitialDimensions, kMapName, kOneMonthInSeconds, kPinColorAttributeName, kPinDataContextName, kPinLatAttributeName,
-  kPinLongAttributeName, kPluginName, kSliderComponentName, kVersion
+  kPinDataContextName, kPinLatAttributeName, kPinLongAttributeName, kPinColorAttributeName,
+  kPluginName, kInitialDimensions, kVersion,
+  kDataContextName, kMapPinsCollectionName, kOneMonthInSeconds,
+  kMapName, kSliderComponentName, kChartGraphName, kXYGraphName,
 } from "../data/constants";
 import { pluginState } from "../models/plugin-state";
-import { kChartGraphName, kDataContextName, kMapPinsCollectionName, kXYGraphName } from "../models/data-manager";
 
 export async function initializeNeoPlugin() {
   initializePlugin({ pluginName: kPluginName, version: kVersion, dimensions: kInitialDimensions });
@@ -120,19 +122,12 @@ export const createOrUpdateGraphs = async (dataContext: string, graphValues: IGr
     existingGraphs.forEach(async (eGraph: any, idx: number) => {
     // Update the existing graph
       const updatedGraph =
-       ((eGraph.title).includes("Plot"))
-        ? await sendMessage("update", `component[${eGraph.id}]`, {
-            type: "graph",
-            dataContext,
-            title: graphValues[idx].title,
-            rescaleAxes: true,
-          })
-        : await sendMessage("update", `component[${eGraph.id}]`, {
-            type: "graph",
-            dataContext,
-            title: graphValues[idx].title,
-            rescaleAxes: true,
-          });
+              await sendMessage("update", `component[${eGraph.id}]`, {
+                type: "graph",
+                dataContext,
+                title: graphValues[idx].title,
+                rescaleAxes: true,
+              });
       return updatedGraph;
     });
   } else {
@@ -158,6 +153,17 @@ export const addConnectingLinesToGraph = async () => {
     showConnectingLines: true,
   });
   return graph;
+};
+
+export const rescaleGraph = async (component: string) => {
+  const request = await codapInterface.sendRequest({
+    "action": "notify",
+    "resource": `component[${component}]`,
+    "values": {
+      "request": "autoScale",
+    }
+  });
+  return request;
 };
 
 export const deleteExistingGraphs = async () => {


### PR DESCRIPTION
Adds static names for both graphs, which was hindering updating the graphs.

Adds rescaling graphs so we don't have to delete and create the graphs on data change.

Simplify props passes to functions that update the graphs.

Needs [CODAP PR #1930](https://github.com/concord-consortium/codap/pull/1930)