### PR TITLE
NASAEARTH-26 handle more cases of pin lat long values

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,5 +1,6 @@
-import { PlaywrightCoverageOptions } from "@bgotink/playwright-coverage";
-import { defineConfig, devices, ReporterDescription } from "@playwright/test";
+import type { PlaywrightCoverageOptions } from "@bgotink/playwright-coverage";
+import type { ReporterDescription } from "@playwright/test";
+import { defineConfig, devices } from "@playwright/test";
 import path, { dirname } from "path";
 import { fileURLToPath } from "url";
 

--- a/src/models/geo-image.test.ts
+++ b/src/models/geo-image.test.ts
@@ -1,0 +1,35 @@
+import { latLongToPixel } from "./geo-image";
+
+describe("latLongToPixel", () => {
+  it("should convert latitude and longitude to pixel coordinates", () => {
+    expect(latLongToPixel(800, 600, 0, 0))
+      .toEqual({ x: 400, y: 300 });
+    expect(latLongToPixel(800, 600, 45, 90))
+      .toEqual({ x: 600, y: 150 });
+    expect(latLongToPixel(800, 600, -45, -90))
+      .toEqual({ x: 200, y: 450 });
+  });
+
+  it("should handle coordinates on the edge of the normal range", () => {
+    expect(latLongToPixel(800, 600, 90, 180))
+      .toEqual({ x: 0, y: 0 });
+    expect(latLongToPixel(800, 600, -90, -180))
+      .toEqual({ x: 0, y: 599 });
+  });
+
+  it("should clamp latitude values outside the range", () => {
+    expect(latLongToPixel(800, 600, 100, 0))
+      .toEqual({ x: 400, y: 0 });
+    expect(latLongToPixel(800, 600, -100, 0))
+      .toEqual({ x: 400, y: 599 });
+  });
+
+  it("should normalize longitude values outside the range", () => {
+    expect(latLongToPixel(800, 600, 0, -160))
+      .toEqual({ x: 44, y: 300 });
+    expect(latLongToPixel(800, 600, 0, 200))
+      .toEqual({ x: 44, y: 300 });
+    expect(latLongToPixel(800, 600, 0, -520))
+      .toEqual({ x: 44, y: 300 });
+  });
+});


### PR DESCRIPTION
- if a user edits the pin table directly and enters partial or invalid values the plugin should not crash
- if the user enters longitude value outside the -180 to 180 range it is normalized so the pixel can still be looked up on the rasters.
- if the user enters a latitude value outside of -90 to 90 it is clamped to be a value in this range.
- fix running playwright tests when using Node v24. It was failing to find the imported types in the playwright.config.ts, by making them explicit type imports node just ignores them so it doesn't look for them.
- extract latLongToPixel into a function outside of GeoImage so it is easier to test